### PR TITLE
Changes to the documentation for working with github pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ export = template;
 * `DebugIO.prefix` - `prefix` variable in `main` placeholder
 
 ## API
-Read about API here: https://github.com/kislball/debugio/blob/master/docs/globals.md
+Read about API [here](https://github.com/kislball/debugio/blob/master/docs/globals.md)
 
 ## License
 MIT

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal


### PR DESCRIPTION
In order for github pages to work, go to settings and select the branch and folder where the documentation will be, then set Minimal theme
![image](https://user-images.githubusercontent.com/54632865/90443418-e6f1e800-e0e4-11ea-9069-507223989826.png)
![image](https://user-images.githubusercontent.com/54632865/90443446-f3764080-e0e4-11ea-963b-6cc82df75874.png)
Example: https://mrlivixx.github.io/debugio/
